### PR TITLE
Changed max transaction size to 128 Mb.

### DIFF
--- a/src/fiber/config.go
+++ b/src/fiber/config.go
@@ -162,5 +162,5 @@ func setDefaults() {
 	viper.SetDefault("params.unlock_time_interval", 60*60*24*365)
 	viper.SetDefault("params.user_max_decimals", 3)
 	viper.SetDefault("params.user_burn_factor", 10)
-	viper.SetDefault("params.user_max_transaction_size", 5 * 1024 * 1024)
+	viper.SetDefault("params.user_max_transaction_size", 128 * 1024 * 1024)
 }

--- a/src/params/params.go
+++ b/src/params/params.go
@@ -121,8 +121,7 @@ var (
 		// BurnFactor can be overriden with `USER_BURN_FACTOR` env var
 		BurnFactor: 100,
 		// MaxTransactionSize can be overriden with `USER_MAX_TXN_SIZE` env var
-		// MaxTransactionSize: 32768, // in bytes
-		MaxTransactionSize: 5242880, // in bytes
+		MaxTransactionSize: 134217728, // in bytes
 		// MaxDropletPrecision can be overriden with `USER_MAX_DECIMALS` env var
 		MaxDropletPrecision: 3,
 	}


### PR DESCRIPTION
Changes:
- Changed max transaction size to 128 Mb.

Does this change need to mentioned in CHANGELOG.md?
No.